### PR TITLE
Separate enums from codeable concepts

### DIFF
--- a/sheet2linkml/source/gsheetmodel/entity.py
+++ b/sheet2linkml/source/gsheetmodel/entity.py
@@ -426,7 +426,7 @@ class Attribute:
 
         # For CodeableConcepts, we specify that the values should come from an enumeration.
         if self.terminology_service and attribute_range == "CodeableConcept":
-            slot.values_from = f'crdch:{Enum.fix_enum_name(self.full_name)}'
+            slot.values_from = f"crdch:{Enum.fix_enum_name(self.full_name)}"
 
         # Multivalued fields need to be inlined as a list.
         # (Eventually, we might want to inline some of these as dicts, but not yet.)

--- a/sheet2linkml/source/gsheetmodel/entity.py
+++ b/sheet2linkml/source/gsheetmodel/entity.py
@@ -424,6 +424,10 @@ class Attribute:
             range=attribute_range,
         )
 
+        # For CodeableConcepts, we specify that the values should come from an enumeration.
+        if self.terminology_service and attribute_range == "CodeableConcept":
+            slot.values_from = f'crdch:{Enum.fix_enum_name(self.full_name)}'
+
         # Multivalued fields need to be inlined as a list.
         # (Eventually, we might want to inline some of these as dicts, but not yet.)
         if max_count is None or max_count > 1:

--- a/sheet2linkml/source/gsheetmodel/entity.py
+++ b/sheet2linkml/source/gsheetmodel/entity.py
@@ -411,13 +411,6 @@ class Attribute:
             examples = [Example(value=example) for example in examples]
 
         attribute_range = self.range
-        # For CodeableConcepts, we currently replace it with an enumeration.
-        # In future versions, we will instead constrain the CodeableConcept's codes in some way.
-        if self.terminology_service and attribute_range == "CodeableConcept":
-            # Logically, we should be able to set `attribute_range` to the EnumDefinition.
-            # But LinkML doesn't support that yet. So instead, we'll refer to the enum definition
-            # here and enter it elsewhere in the YAML file.
-            attribute_range = Enum.fix_enum_name(self.full_name)
 
         slot: SlotDefinition = SlotDefinition(
             name=data.get(EntityWorksheet.COL_ATTRIBUTE_NAME) or "",


### PR DESCRIPTION
It looks like the changes made in PR https://github.com/cancerDHC/ccdhmodel/pull/115 were somehow not moved into this repo! This PR moves those changes over. Tests would be nice but we don't have a testing framework here yet.

This PR removes the codeable-concept-to-enum replacement step that we were previously taking, which is no longer necessary. Instead, the enum identifier is stored in the LinkML [`values_from`](https://linkml.io/linkml-model/docs/values_from/) field.