### PR TITLE
Respond correctly to 404 responses when communicating with the CCDH service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Releases](https://github.com/cancerDHC/sheet2linkml/releases)
 
 ## [Unreleased]
+* Fixed bug: correctly handle 404 responses from the TCCM Terminology Service
 
 ## [v1.2.0] - 2021-11-29
 

--- a/sheet2linkml/terminologies/tccm/api.py
+++ b/sheet2linkml/terminologies/tccm/api.py
@@ -40,7 +40,10 @@ class TCCMService(TerminologyService):
         response = requests.get(
             url, headers={"accept": "application/x-yaml"}, params={"value_only": "true"}
         )
-        if not response.ok:
+        if response.status_code == 404:
+            logging.debug(f"Field not found on TCCM Terminology Service ({field_name}): {response}")
+            return {}
+        elif not response.ok:
             logging.debug(f"Error accessing TCCM Terminology Service: {response}")
             return {}
 

--- a/sheet2linkml/terminologies/tccm/api.py
+++ b/sheet2linkml/terminologies/tccm/api.py
@@ -41,7 +41,9 @@ class TCCMService(TerminologyService):
             url, headers={"accept": "application/x-yaml"}, params={"value_only": "true"}
         )
         if response.status_code == 404:
-            logging.debug(f"Field not found on TCCM Terminology Service ({field_name}): {response}")
+            logging.debug(
+                f"Field not found on TCCM Terminology Service ({field_name}): {response}"
+            )
             return {}
         elif not response.ok:
             logging.debug(f"Error accessing TCCM Terminology Service: {response}")


### PR DESCRIPTION
The CCDH Terminology Service now returns an HTTP 404 message when a field either doesn't exist or doesn't have known permissible values. This PR adds support for that to the Terminology Service communication library.

(This change is already present in PR #21, but we're working on that PR as a group, so this is a way of getting that change into sheet2linkml more quickly.)